### PR TITLE
Add authentication and role-based access controls

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,9 +5,13 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from enum import Enum
+from uuid import uuid4
+
+from fastapi import FastAPI, Header, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
 import os
 from pathlib import Path
 
@@ -78,6 +82,59 @@ activities = {
 }
 
 
+class Role(str, Enum):
+    student = "student"
+    parent = "parent"
+    provider = "provider"
+    admin = "admin"
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+# In-memory users for this exercise.
+users = {
+    "student1": {
+        "password": "student123",
+        "role": Role.student,
+    },
+    "parent1": {
+        "password": "parent123",
+        "role": Role.parent,
+    },
+    "provider1": {
+        "password": "provider123",
+        "role": Role.provider,
+    },
+    "admin1": {
+        "password": "admin123",
+        "role": Role.admin,
+    },
+}
+
+# token -> user session mapping
+sessions: dict[str, dict] = {}
+
+
+def get_current_user(authorization: str | None):
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    token = authorization.replace("Bearer ", "", 1).strip()
+    session = sessions.get(token)
+    if session is None:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    return session
+
+
+def require_role(user: dict, allowed_roles: set[Role]):
+    if user["role"] not in allowed_roles:
+        raise HTTPException(status_code=403, detail="Forbidden for your role")
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -88,9 +145,48 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def login(payload: LoginRequest):
+    user = users.get(payload.username)
+    if user is None or user["password"] != payload.password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = str(uuid4())
+    sessions[token] = {
+        "username": payload.username,
+        "role": user["role"],
+    }
+
+    return {
+        "token": token,
+        "username": payload.username,
+        "role": user["role"],
+    }
+
+
+@app.post("/auth/logout")
+def logout(authorization: str | None = Header(default=None)):
+    user = get_current_user(authorization)
+    token = authorization.replace("Bearer ", "", 1).strip()
+    sessions.pop(token, None)
+    return {"message": f"Logged out {user['username']}"}
+
+
+@app.get("/auth/me")
+def me(authorization: str | None = Header(default=None)):
+    return get_current_user(authorization)
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    authorization: str | None = Header(default=None),
+):
     """Sign up a student for an activity"""
+    user = get_current_user(authorization)
+    require_role(user, {Role.parent, Role.provider, Role.admin})
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +207,15 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    authorization: str | None = Header(default=None),
+):
     """Unregister a student from an activity"""
+    user = get_current_user(authorization)
+    require_role(user, {Role.provider, Role.admin})
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,82 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const authForm = document.getElementById("auth-form");
+  const authStatus = document.getElementById("auth-status");
+  const logoutBtn = document.getElementById("logout-btn");
+  const signupContainer = document.getElementById("signup-container");
+
+  let currentUser = null;
+
+  function getToken() {
+    return localStorage.getItem("authToken");
+  }
+
+  function authHeaders() {
+    const token = getToken();
+    if (!token) {
+      return {};
+    }
+    return { Authorization: `Bearer ${token}` };
+  }
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function updateAuthUI() {
+    if (!currentUser) {
+      authStatus.textContent = "Browsing as guest";
+      logoutBtn.classList.add("hidden");
+      signupContainer.classList.add("hidden");
+      return;
+    }
+
+    authStatus.textContent = `Logged in as ${currentUser.username} (${currentUser.role})`;
+    logoutBtn.classList.remove("hidden");
+
+    const canSignup = ["parent", "provider", "admin"].includes(currentUser.role);
+    if (canSignup) {
+      signupContainer.classList.remove("hidden");
+    } else {
+      signupContainer.classList.add("hidden");
+    }
+  }
+
+  async function restoreSession() {
+    const token = getToken();
+    if (!token) {
+      currentUser = null;
+      updateAuthUI();
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/me", {
+        headers: authHeaders(),
+      });
+
+      if (!response.ok) {
+        localStorage.removeItem("authToken");
+        currentUser = null;
+        updateAuthUI();
+        return;
+      }
+
+      currentUser = await response.json();
+      updateAuthUI();
+    } catch (error) {
+      currentUser = null;
+      updateAuthUI();
+      console.error("Error restoring session:", error);
+    }
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -30,7 +106,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span><button class="delete-btn hidden" data-activity="${name}" data-email="${email}">❌</button></li>`
                   )
                   .join("")}
               </ul>
@@ -58,6 +134,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Add event listeners to delete buttons
       document.querySelectorAll(".delete-btn").forEach((button) => {
+        const canDelete =
+          currentUser && ["provider", "admin"].includes(currentUser.role);
+        if (canDelete) {
+          button.classList.remove("hidden");
+        }
         button.addEventListener("click", handleUnregister);
       });
     } catch (error) {
@@ -80,35 +161,80 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: authHeaders(),
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
+
+  authForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Login failed", "error");
+        return;
+      }
+
+      localStorage.setItem("authToken", result.token);
+      currentUser = {
+        username: result.username,
+        role: result.role,
+      };
+
+      authForm.reset();
+      updateAuthUI();
+      showMessage("Login successful", "success");
+      fetchActivities();
+    } catch (error) {
+      showMessage("Login failed. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: authHeaders(),
+      });
+    } catch (error) {
+      console.error("Error logging out:", error);
+    }
+
+    localStorage.removeItem("authToken");
+    currentUser = null;
+    updateAuthUI();
+    showMessage("Logged out", "info");
+    fetchActivities();
+  });
 
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
@@ -124,37 +250,27 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: authHeaders(),
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
   // Initialize app
-  fetchActivities();
+  restoreSession().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,15 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-panel">
+        <form id="auth-form">
+          <input type="text" id="username" placeholder="Username" required />
+          <input type="password" id="password" placeholder="Password" required />
+          <button type="submit">Sign In</button>
+        </form>
+        <p id="auth-status">Browsing as guest</p>
+        <button id="logout-btn" class="hidden" type="button">Sign Out</button>
+      </div>
     </header>
 
     <main>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -28,6 +28,41 @@ header h1 {
   margin-bottom: 10px;
 }
 
+#auth-panel {
+  margin-top: 15px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+#auth-form {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+}
+
+#auth-form input {
+  padding: 8px;
+  border: 1px solid #c5cae9;
+  border-radius: 4px;
+  min-width: 150px;
+}
+
+#auth-status {
+  font-size: 14px;
+  opacity: 0.95;
+}
+
+#logout-btn {
+  background-color: #283593;
+}
+
+#logout-btn:hover {
+  background-color: #303f9f;
+}
+
 main {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
Implements a basic authentication flow with role-based access controls for the activities app.

## What changed
- Added auth endpoints:
  - `POST /auth/login`
  - `POST /auth/logout`
  - `GET /auth/me`
- Added in-memory users with roles: student, parent, provider, admin
- Added in-memory bearer-token session handling
- Protected mutation endpoints:
  - `POST /activities/{activity_name}/signup` now requires `parent`, `provider`, or `admin`
  - `DELETE /activities/{activity_name}/unregister` now requires `provider` or `admin`
- Updated frontend to support:
  - Sign in / sign out UI
  - Token persistence in `localStorage`
  - Role-aware visibility of signup and unregister actions

## Validation
- Confirmed public activity browsing remains open
- Confirmed unauthorized signup is blocked with `401`
- Confirmed role restrictions return `403` when appropriate
- Confirmed allowed roles can perform their actions

Fixes #8